### PR TITLE
Atualização do PHPMailer devido a falha de segurança do phpmailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : ">= 7.0",
-        "phpmailer/phpmailer": "^5.2",
+        "phpmailer/phpmailer": "^6.1",
         "soundasleep/html2text": "~0.3"
     },
     "require-dev": {

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -16,7 +16,7 @@ namespace NFePHP\Mail;
  */
 
 use NFePHP\Mail\Base;
-use PHPMailer;
+use PHPMailer\PHPMailer\PHPMailer;
 use Html2Text\Html2Text;
 
 class Mail extends Base

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -35,11 +35,14 @@ class Mail extends Base
     /**
      * Constructor
      * @param \stdClass $config
+     * @param PHPMailer $mailer
      */
-    public function __construct(\stdClass $config)
+    public function __construct(\stdClass $config, PHPMailer $mailer = null)
     {
-        $this->mail = new PHPMailer();
-        
+        $this->mail = $mailer;
+        if (is_null($mailer)) {
+            $this->mail = new PHPMailer();
+        }
         $this->config = $config;
         $this->loadService($config);
         $this->fields = new \stdClass();
@@ -78,6 +81,9 @@ class Mail extends Base
         }
         if (!empty($config->timelimit)) {
             $this->mail->Timelimit = $config->timelimit;
+        }
+        if (!empty($config->smtpoptions) && is_array($config->smtpoptions)) {
+            $this->mail->SMTPOptions = $config->smtpoptions;
         }
         $this->mail->setFrom($config->from, $config->fantasy);
         $this->mail->addReplyTo($config->replyTo, $config->replyName);


### PR DESCRIPTION
As versões do PHPMailer anteriores a 6.0.6 e 5.2.27 são vulneráveis ​​a um ataque de injeção de objeto, passando caminhos phar: // para addAttachment() outras funções que podem receber caminhos locais não filtrados, possivelmente levando ao RCE. Consulte este artigo para obter mais informações sobre esse tipo de vulnerabilidade. Atenuado, bloqueando o uso de caminhos que contêm prefixos de estilo de protocolo de URL, como phar://. Relatado por Sehun Oh, do cyberone.kr.